### PR TITLE
Add ability to use backup (via symlink) and small cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ gitkraken_backup_use_symlink: false
 
 # Directory of source dir to symlink to ~/.gitkraken
 gitkraken_backup_src_dir: '' # Must be defined to use & above boolean must be set to true
+
+# Default way to detect the home directory for use with the backup directory
+# This is not ideal as this will report the user that Ansible is running as
+os_username: "{{ lookup('env','USER') }}"
 ```
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ gitkraken_redis_url: https://release.gitkraken.com/linux/gitkraken-amd64.deb
 
 # Directory to store files downloaded for GitKraken installation
 gitkraken_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+
+# Should the config dir be replaced with a symlink to a backup directory
+gitkraken_backup_use_symlink: false
+
+# Directory of source dir to symlink to ~/.gitkraken
+gitkraken_backup_src_dir: '' # Must be defined to use & above boolean must be set to true
 ```
 
 Example Playbook
@@ -40,6 +46,15 @@ Example Playbook
   roles:
      - { role: gantsign.gitkraken }
 ```
+```yaml
+- hosts: servers
+  vars:
+    - os_username: myUserName
+    - gitkraken_backup_use_symlink: true
+    - gitkraken_backup_src_dir: /path/to/your/backup/dir
+  roles:
+     - { role: gantsign.gitkraken }
+```   
 
 More Roles From GantSign
 ------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,8 @@ gitkraken_redis_url: https://release.gitkraken.com/linux/gitkraken-amd64.deb
 # Directory to store files downloaded for GitKraken installation
 gitkraken_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 
+# Should the config dir be replaced with a symlink to a backup directory
+gitkraken_backup_use_symlink: false
+
 # Directory path of dir to symlink to ~/.gitkraken
 gitkraken_backup_src_dir: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ gitkraken_redis_url: https://release.gitkraken.com/linux/gitkraken-amd64.deb
 
 # Directory to store files downloaded for GitKraken installation
 gitkraken_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
+
+# Directory path of dir to symlink to ~/.gitkraken
+gitkraken_backup_src_dir: ''

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for gitkraken

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,3 +63,11 @@
   become: yes
   apt:
     deb: '{{ gitkraken_download_dir }}/{{ gitkraken_redis_filename }}'
+
+- name: symlink backup directory
+  file:
+    dest: '/home/{{ os_username }}/.gitkraken'
+    src:  '{{ gitkraken_backup_src_dir }}'
+    state: link
+  when: gitkraken_backup_use_symlink and gitkraken_backup_src_dir is defined
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,8 +66,7 @@
 
 - name: symlink backup directory
   file:
-    dest: '/home/{{ os_username }}/.gitkraken'
     src:  '{{ gitkraken_backup_src_dir }}'
+    dest: '/home/{{ os_username }}/.gitkraken'
     state: link
   when: gitkraken_backup_use_symlink and gitkraken_backup_src_dir is defined
-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,9 @@ gitkraken_etag_path: '{{ gitkraken_download_dir }}/{{ gitkraken_redis_filename }
 
 # Default value for existing etag
 gitkraken_existing_etag: none
+
+# Default way to detect the home directory for use with the backup directory
+# This is not ideal as this will report the user that Ansible is running as
+os_username: "{{ lookup('env','USER') }}"
+
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,9 +6,3 @@ gitkraken_etag_path: '{{ gitkraken_download_dir }}/{{ gitkraken_redis_filename }
 
 # Default value for existing etag
 gitkraken_existing_etag: none
-
-# Default way to detect the home directory for use with the backup directory
-# This is not ideal as this will report the user that Ansible is running as
-os_username: "{{ lookup('env','USER') }}"
-
-


### PR DESCRIPTION
Removed handlers as they will never be used

Added several vars to control how to manage using a symlink for the default /home/<UserName>/.gitkraken directory. I personally sync all my configs offsite so this is very useful for me. I'd like to add the ability to "copy" over backups but another time.